### PR TITLE
Upgrade rust-rocksdb from 0.3.5 to 0.6.0 (RocksDB 4.13.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ build = "build.rs"
 [build-dependencies]
 
 [dependencies]
-byteorder = "0.5.3"
-lazy_static = "0.2.1"
+byteorder = "1.0.0"
+lazy_static = "0.2.2"
 promising-future = "0.2.4"
-rmp-serialize = "0.7.0"
-rocksdb = "0.3.5"
+rmp-serialize = "0.8.0"
+rocksdb = "0.6.0"
 rust-crypto = "0.2.36"
-rustc-serialize = "0.3.19"
+rustc-serialize = "0.3.22"
 
 clippy = { version = "*", optional = true }

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Dropbox and Mozilla (Firefox):
     release and a nightly build of Rust tool-chains.
   * More info about rustup.rs:
     [Taking Rust everywhere with rustup](https://blog.rust-lang.org/2016/05/13/rustup.html)
-- RocksDB library
-  * On Linux, **TODO**
-  * On FreeBSD, `sudo pkg install rocksdb` (Tested with RockDB 4.6.1)
+- Tools and libraries to build RocksDB
+  * On Linux (Ubuntu), `sudo apt install gcc make libgflags-dev`
+  * On FreeBSD, **TODO**
 
 
 ### Building and Running
@@ -75,7 +75,7 @@ Install [Valgrind](http://valgrind.org/)
 
 ```
 # Ubuntu
-$ sudo apt-get install valgrind
+$ sudo apt install valgrind
 
 # FreeBSD
 $ sudo pkg install valgrind
@@ -99,7 +99,7 @@ $ cargo profiler cachegrind --bin ./target/release/hibari-brick-rs -n 50
 ### Documentation
 
 There is no documentation (including rustdoc) at this point as the API
-is changing everyday. Maybe you want to read source code in
+will be changing everyday. Maybe you want to read source code in
 [main.rs](https://github.com/hibari/hibari-brick-rs/blob/master/src/main.rs)
 and
 [lib.rs](https://github.com/hibari/hibari-brick-rs/blob/master/src/lib.rs)

--- a/circle.yml
+++ b/circle.yml
@@ -31,13 +31,6 @@ dependencies:
     - rustup run beta cargo --version --verbose
     - rustup run nightly rustc --version --verbose
     - rustup run nightly cargo --version --verbose
-    # Build and install RocksDB (DISABLED)
-    # - cd $HOME; curl -L -O https://github.com/facebook/rocksdb/archive/v${ROCKSDB_RELEASE}.tar.gz
-    # - cd $HOME; tar xvf v${ROCKSDB_RELEASE}.tar.gz && cd rocksdb-${ROCKSDB_RELEASE} && make shared_lib && sudo make install
-    # Install a pre-built RocksDB (DISABLED)
-    # - sudo cp -p ./tools/circleci/files/librocksdb.so.4.9.0.ubuntu-14.04-x86_64.xz /usr/local/lib/librocksdb.so.4.9.0.xz
-    # - cd /usr/local/lib && sudo xz -d librocksdb.so.4.9.0.xz && sudo ln -fs librocksdb.so.4.9.0 librocksdb.so.4.9 && sudo ln -fs librocksdb.so.4.9.0 librocksdb.so.4 && sudo ln -fs librocksdb.so.4.9.0 librocksdb.so
-    # - ls -l /usr/local/lib/librocksdb*
   cache_directories:
     - "~/.cargo"
 
@@ -45,14 +38,12 @@ test:
   override:
     - rustup run nightly cargo clean
     - rustup run nightly cargo build --features=clippy:
-        timeout: 1200
+        timeout: 900
     - rustup run stable cargo clean
-    - rustup run stable cargo test:
-        timeout: 1200
-    - rustup run stable cargo run --release:
-        timeout: 1200
+    - rustup run stable cargo test --release:
+        timeout: 900
+    - rustup run stable cargo run --release
     - rustup run beta cargo clean
-    - rustup run beta cargo test:
-        timeout: 1200
-    - rustup run beta cargo run --release:
-        timeout: 1200
+    - rustup run beta cargo test --release:
+        timeout: 900
+    - rustup run beta cargo run --release

--- a/circle.yml
+++ b/circle.yml
@@ -44,10 +44,15 @@ dependencies:
 test:
   override:
     - rustup run nightly cargo clean
-    - rustup run nightly cargo build --features=clippy
+    - rustup run nightly cargo build --features=clippy:
+        timeout: 1200
     - rustup run stable cargo clean
-    - rustup run stable cargo test
-    - rustup run stable cargo run --release
+    - rustup run stable cargo test:
+        timeout: 1200
+    - rustup run stable cargo run --release:
+        timeout: 1200
     - rustup run beta cargo clean
-    - rustup run beta cargo test
-    - rustup run beta cargo run --release
+    - rustup run beta cargo test:
+        timeout: 1200
+    - rustup run beta cargo run --release:
+        timeout: 1200

--- a/circle.yml
+++ b/circle.yml
@@ -34,10 +34,10 @@ dependencies:
     # Build and install RocksDB (DISABLED)
     # - cd $HOME; curl -L -O https://github.com/facebook/rocksdb/archive/v${ROCKSDB_RELEASE}.tar.gz
     # - cd $HOME; tar xvf v${ROCKSDB_RELEASE}.tar.gz && cd rocksdb-${ROCKSDB_RELEASE} && make shared_lib && sudo make install
-    # Install a pre-built RocksDB
-    - sudo cp -p ./tools/circleci/files/librocksdb.so.4.9.0.ubuntu-14.04-x86_64.xz /usr/local/lib/librocksdb.so.4.9.0.xz
-    - cd /usr/local/lib && sudo xz -d librocksdb.so.4.9.0.xz && sudo ln -fs librocksdb.so.4.9.0 librocksdb.so.4.9 && sudo ln -fs librocksdb.so.4.9.0 librocksdb.so.4 && sudo ln -fs librocksdb.so.4.9.0 librocksdb.so
-    - ls -l /usr/local/lib/librocksdb*
+    # Install a pre-built RocksDB (DISABLED)
+    # - sudo cp -p ./tools/circleci/files/librocksdb.so.4.9.0.ubuntu-14.04-x86_64.xz /usr/local/lib/librocksdb.so.4.9.0.xz
+    # - cd /usr/local/lib && sudo xz -d librocksdb.so.4.9.0.xz && sudo ln -fs librocksdb.so.4.9.0 librocksdb.so.4.9 && sudo ln -fs librocksdb.so.4.9.0 librocksdb.so.4 && sudo ln -fs librocksdb.so.4.9.0 librocksdb.so
+    # - ls -l /usr/local/lib/librocksdb*
   cache_directories:
     - "~/.cargo"
 
@@ -51,4 +51,3 @@ test:
     - rustup run beta cargo clean
     - rustup run beta cargo test
     - rustup run beta cargo run --release
-

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,9 @@ machine:
     Asia/Shanghai
   environment:
     PATH: $PATH:$HOME/.cargo/bin
+    # Parallel gcc jobs for building Snappy and RocksDB.
+    # See: https://github.com/hibari/hibari-brick-rs/issues/3
+    NUM_JOBS: 4
 
 dependencies:
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -14,9 +14,9 @@ machine:
 
 dependencies:
   post:
-    - sudo apt-get update
-    - sudo apt-get install curl file gcc git make openssh-client xz-utils
-    - sudo apt-get install libgflags-dev
+    - sudo apt update
+    - sudo apt install curl file gcc git make openssh-client
+    - sudo apt install libgflags-dev
     # Delete .gitconfig to prevent "cargo install" and "cargo build" from
     # failing when pulling the registry info (crates.io-index).
     # See https://github.com/rust-lang-ja/rust-by-example-ja/issues/38#issuecomment-238214915

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
   post:
     - sudo apt-get update
     - sudo apt-get install curl file gcc git make openssh-client xz-utils
-    - sudo apt-get install libgflags-dev libsnappy-dev
+    - sudo apt-get install libgflags-dev
     # Delete .gitconfig to prevent "cargo install" and "cargo build" from
     # failing when pulling the registry info (crates.io-index).
     # See https://github.com/rust-lang-ja/rust-by-example-ja/issues/38#issuecomment-238214915

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ machine:
     PATH: $PATH:$HOME/.cargo/bin
     # Parallel gcc jobs for building Snappy and RocksDB.
     # See: https://github.com/hibari/hibari-brick-rs/issues/3
-    NUM_JOBS: 4
+    CI_NUM_JOBS: 4
 
 dependencies:
   post:
@@ -40,13 +40,13 @@ dependencies:
 test:
   override:
     - rustup run nightly cargo clean
-    - rustup run nightly cargo build --features=clippy:
+    - rustup run nightly cargo build --jobs $CI_NUM_JOBS --features=clippy:
         timeout: 900
     - rustup run stable cargo clean
-    - rustup run stable cargo test --release:
+    - rustup run stable cargo test --jobs $CI_NUM_JOBS --release:
         timeout: 900
     - rustup run stable cargo run --release
     - rustup run beta cargo clean
-    - rustup run beta cargo test --release:
+    - rustup run beta cargo test --jobs $CI_NUM_JOBS --release:
         timeout: 900
     - rustup run beta cargo run --release

--- a/src/hlog/hunk.rs
+++ b/src/hlog/hunk.rs
@@ -452,7 +452,7 @@ fn append_hunk_footer(hunk: &mut Vec<u8>,
     hunk.extend_from_slice(HUNK_FOOTER_MAGIC);
 
     if let Some(md5) = md5 {
-        hunk.write(&md5).unwrap();
+        hunk.write_all(&md5).unwrap();
     }
     if *hunk_type == HunkType::Metadata || *hunk_type == HunkType::BlobWal {
         if let Some(mut bn) = encoded_brick_name {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use crypto::digest::Digest;
 use crypto::md5::Md5;
 
 use msgpack::{Encoder, Decoder};
-use rocksdb::{DB, Options, Writable};
+use rocksdb::{DB, Options};
 use rustc_serialize::{Encodable, Decodable};
 
 use std::io;
@@ -41,7 +41,7 @@ const MAIN_DB_PATH: &'static str = "/tmp/hibari-brick-test-data-rocksdb";
 
 lazy_static! {
     static ref MAIN_DB: DB = {
-        let mut opts = Options::new();
+        let mut opts = Options::default();
         opts.create_if_missing(true);
 
         DB::open(&opts, MAIN_DB_PATH).unwrap()


### PR DESCRIPTION
Upgrade rust-rocksdb crate from 0.3.5 to 0.6.0. It contains [RocksDB 4.13.0](https://github.com/facebook/rocksdb/blob/f201a44b4102308b840b15d9b89122af787476f1/HISTORY.md), released on 10/18/2016.

Some highlights from rust-rocksdb's [change log](https://github.com/spacejam/rust-rocksdb/blob/master/CHANGELOG.txt):
- The RocksDB library is now built at crate compile-time and statically linked with the resulting binary
- Windows support

I have not tried if hibari-brick-rs can be built and run on Windows, but it will, as there is no platform dependent code in the repository.