### PR TITLE
Replace md5 storage checksum with Blake2b

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,10 @@ build = "build.rs"
 [build-dependencies]
 
 [dependencies]
+blake2-rfc = "0.2.17"
 byteorder = "1.0.0"
 data-encoding = "2.0.0-rc.1"
-generic-array = "0.7.2"
 lazy_static = "0.2.2"
-md-5 = "0.4.3"
 promising-future = "0.2.4"
 rmp-serde = "0.13.1"
 rocksdb = "0.6.0"

--- a/examples/hashes/.gitignore
+++ b/examples/hashes/.gitignore
@@ -1,0 +1,2 @@
+target/
+**/*.rs.bk

--- a/examples/hashes/Cargo.toml
+++ b/examples/hashes/Cargo.toml
@@ -5,11 +5,12 @@ authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 
 [dependencies]
 blake2 = "0.5.2"
+blake2-rfc = "0.2.17"
 data-encoding = "2.0.0-rc.1"
 # generic-array = "0.7.2"
 md-5 = { version = "0.4.3", features = ["asm"] }
 # md-5 = "0.4.3"
 rand = "0.3.15"
-# sha2 = { version = "0.5.2", features = ["asm"] }
-sha2 = "0.5.2"
+sha2 = { version = "0.5.2", features = ["asm"] }
+# sha2 = "0.5.2"
 sha3 = "0.5.1"

--- a/examples/hashes/Cargo.toml
+++ b/examples/hashes/Cargo.toml
@@ -7,6 +7,8 @@ authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
 blake2 = "0.5.2"
 data-encoding = "2.0.0-rc.1"
 # generic-array = "0.7.2"
+md-5 = { version = "0.4.3", features = ["asm"] }
+# md-5 = "0.4.3"
 rand = "0.3.15"
 # sha2 = { version = "0.5.2", features = ["asm"] }
 sha2 = "0.5.2"

--- a/examples/hashes/Cargo.toml
+++ b/examples/hashes/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "hashes"
+version = "0.1.0"
+authors = ["Tatsuya Kawano <tatsuya@hibaridb.org>"]
+
+[dependencies]
+blake2 = "0.5.2"
+data-encoding = "2.0.0-rc.1"
+# generic-array = "0.7.2"
+rand = "0.3.15"
+# sha2 = { version = "0.5.2", features = ["asm"] }
+sha2 = "0.5.2"
+sha3 = "0.5.1"

--- a/examples/hashes/README.md
+++ b/examples/hashes/README.md
@@ -1,0 +1,34 @@
+# A Simple Benchmark for Secure Hash Implementation in Rust
+
+This is a very simple benchmark program to compare performance (speed)
+between the following secure hash functions implemented in Rust:
+
+- **SHA-256**
+  * crates: [sha2](https://crates.io/crates/sha2) 0.5.2,
+    [sha2-asm](https://crates.io/crates/sha2-asm) 0.2.1
+- **SHA-3-256**
+  * crate: [sha3](https://crates.io/crates/sha3) 0.5.1
+- **Blake2s**
+  * crate: [blake2](https://crates.io/crates/blake2) 0.5.2
+
+It creates a `Vec<u8>` holding 8GB of random bytes, then calculate
+secure hash using these hash functions, and compare time to complete.
+
+
+## Running the Benchmark
+
+```
+$ cargo run --release
+```
+
+For example,
+
+```
+$ cargo run --release
+...
+Input data length: 8.00 GB
+SHA-256   - 38.16 seconds (38162777286 nano-seconds), digest: "69de2109a91cd2dccf6d1ec447fa3975c0c44ab32459e178e31569bff09ce9d1"
+SHA-3-256 - 74.51 seconds (74507281950 nano-seconds), digest: "8e41cb790bc5c80b3fe339f17d1b1c8871c0afe888a0e2692efbdc7e55656203"
+Blake2s   - 18.57 seconds (18571153963 nano-seconds), digest: "ccae52d11f9e49ba565635be5e88533444392f869f9d0fc1b66d76bc85b33042"
+SHA-256: 1.00x, SHA-3-256: 0.51x, Blake2s: 2.05x
+```

--- a/examples/hashes/src/main.rs
+++ b/examples/hashes/src/main.rs
@@ -15,6 +15,7 @@
 // ----------------------------------------------------------------------
 
 extern crate blake2;
+extern crate blake2_rfc;
 extern crate md_5 as md5;
 extern crate sha2;
 extern crate sha3;
@@ -25,36 +26,73 @@ extern crate data_encoding;
 use std::time::Instant;
 
 // use digest::Digest;
-use blake2::{Blake2s, Digest};
+use blake2::{Blake2b, Blake2s, Digest};
+use blake2_rfc::blake2b::blake2b;
 use md5::Md5;
-use sha2::Sha256;
-use sha3::Sha3_256;
+use sha2::{Sha256, Sha512};
+use sha3::{Sha3_256, Sha3_512};
 
 use data_encoding::HEXLOWER;
 use rand::{Rng, SeedableRng, XorShiftRng};
 
+const GB: usize = 1024 * 1024 * 1024;
+
 fn main() {
-    let input_len = 8 * 1024 * 1024 * 1024;
+    let input_len = 8 * GB;
+    // let input_len = 1024 * 1024;
+    let input = generate_input(input_len);
 
-    println!("Input data length: {:.2} GB", input_len as f64 / 1024.0 / 1024.0 / 1024.0);
+    let dur_md5 =      hash::<Md5>(&input[..],      "MD5 (asm)     ");
+    let dur_sha256 =   hash::<Sha256>(&input[..],   "SHA-256 (asm) ");
+    let dur_sha3_256 = hash::<Sha3_256>(&input[..], "SHA-3-256     ");
+    let dur_blake2s =  hash::<Blake2s>(&input[..],  "Blake2s       ");
+    let dur_blake2b_rfc = hash_blake2b_rfc(&input[..]);
+    let dur_sha512 =   hash::<Sha512>(&input[..],   "SHA-512 (asm) ");
+    let dur_sha3_512 = hash::<Sha3_512>(&input[..], "SHA-3-512     ");
+    let dur_blake2b =  hash::<Blake2b>(&input[..],  "Blake2b       ");
 
-    let elapse_md5 = hash::<Md5>(input_len, "MD5      ");
-    let elapse_sha256 = hash::<Sha256>(input_len, "SHA-256  ");
-    let elapse_sha3_256 = hash::<Sha3_256>(input_len, "SHA-3-256");
-    let elapse_blake2 = hash::<Blake2s>(input_len, "Blake2s  ");
-
-    println!("MD5: {:.2}x, SHA-256: 1.00x, SHA-3-256: {:.2}x, Blake2s: {:.2}x",
-             elapse_sha256 / elapse_md5,
-             elapse_sha256 / elapse_sha3_256,
-             elapse_sha256 / elapse_blake2);
+    println!(r"
+Speed ups:
+  MD5 (asm):     {:.2}x
+  SHA-256 (asm): 1.00x
+  SHA-3-256:     {:.2}x
+  Blake2s (256)  {:.2}x
+  Blake2b (256): {:.2}x
+  SHA-512 (asm): {:.2}x
+  SHA-3-512:     {:.2}x
+  Blake2b (512): {:.2}x",
+             dur_sha256 / dur_md5,
+             dur_sha256 / dur_sha3_256,
+             dur_sha256 / dur_blake2s,
+             dur_sha256 / dur_blake2b_rfc,
+             dur_sha256 / dur_sha512,
+             dur_sha256 / dur_sha3_512,
+             dur_sha256 / dur_blake2b);
 }
 
-fn hash<D: Digest + Default>(input_len: usize, label: &str) -> f64 {
-    let input = generate_input(input_len);
+fn generate_input(len: usize) -> Vec<u8> {
+    println!("Generating a random input data (length: {:.2} GB)", len as f64 / GB as f64);
+
     let start = Instant::now();
+
+    let mut rng = XorShiftRng::from_seed([0, 1, 2, 3]);
+    let input = rng.gen_iter().take(len).collect();
+
+    let dur = Instant::now() - start;
+    let nano_secs = dur.subsec_nanos() as f64 + dur.as_secs() as f64 * 1e9_f64;
+    println!("Generated the random input data in {:.2} seconds ({:.0} nano-seconds)\n",
+             nano_secs / 1e9_f64,
+             nano_secs);
+    input
+}
+
+fn hash<D: Digest + Default>(input: &[u8], label: &str) -> f64 {
+    let start = Instant::now();
+
     let mut hasher = D::default();
     hasher.input(&input[..]);
     let digest = hasher.result();
+
     let dur = Instant::now() - start;
     let nano_secs = dur.subsec_nanos() as f64 + dur.as_secs() as f64 * 1e9_f64;
     println!("{} - {:.2} seconds ({:.0} nano-seconds), digest: {:?}", 
@@ -65,7 +103,16 @@ fn hash<D: Digest + Default>(input_len: usize, label: &str) -> f64 {
     nano_secs
 }
 
-fn generate_input(len: usize) -> Vec<u8> {
-    let mut rng = XorShiftRng::from_seed([0, 1, 2, 3]);
-    rng.gen_iter().take(len).collect()
+fn hash_blake2b_rfc(input: &[u8]) -> f64 {
+    let start = Instant::now();
+
+    let digest = blake2b(32, &[], input);
+
+    let dur = Instant::now() - start;
+    let nano_secs = dur.subsec_nanos() as f64 + dur.as_secs() as f64 * 1e9_f64;
+    println!("Blake2b (256): - {:.2} seconds ({:.0} nano-seconds), digest: {:?}", 
+             nano_secs / 1e9_f64, 
+             nano_secs, 
+             HEXLOWER.encode(digest.as_bytes()));
+    nano_secs
 }

--- a/examples/hashes/src/main.rs
+++ b/examples/hashes/src/main.rs
@@ -15,15 +15,18 @@
 // ----------------------------------------------------------------------
 
 extern crate blake2;
-extern crate data_encoding;
-extern crate rand;
+extern crate md_5 as md5;
 extern crate sha2;
 extern crate sha3;
+
+extern crate rand;
+extern crate data_encoding;
 
 use std::time::Instant;
 
 // use digest::Digest;
 use blake2::{Blake2s, Digest};
+use md5::Md5;
 use sha2::Sha256;
 use sha3::Sha3_256;
 
@@ -35,11 +38,13 @@ fn main() {
 
     println!("Input data length: {:.2} GB", input_len as f64 / 1024.0 / 1024.0 / 1024.0);
 
+    let elapse_md5 = hash::<Md5>(input_len, "MD5      ");
     let elapse_sha256 = hash::<Sha256>(input_len, "SHA-256  ");
     let elapse_sha3_256 = hash::<Sha3_256>(input_len, "SHA-3-256");
     let elapse_blake2 = hash::<Blake2s>(input_len, "Blake2s  ");
 
-    println!("SHA-256: 1.00x, SHA-3-256: {:.2}x, Blake2s: {:.2}x",
+    println!("MD5: {:.2}x, SHA-256: 1.00x, SHA-3-256: {:.2}x, Blake2s: {:.2}x",
+             elapse_sha256 / elapse_md5,
              elapse_sha256 / elapse_sha3_256,
              elapse_sha256 / elapse_blake2);
 }

--- a/examples/hashes/src/main.rs
+++ b/examples/hashes/src/main.rs
@@ -1,0 +1,66 @@
+// ----------------------------------------------------------------------
+//  Copyright (c) 2017 Hibari developers. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ----------------------------------------------------------------------
+
+extern crate blake2;
+extern crate data_encoding;
+extern crate rand;
+extern crate sha2;
+extern crate sha3;
+
+use std::time::Instant;
+
+// use digest::Digest;
+use blake2::{Blake2s, Digest};
+use sha2::Sha256;
+use sha3::Sha3_256;
+
+use data_encoding::HEXLOWER;
+use rand::{Rng, SeedableRng, XorShiftRng};
+
+fn main() {
+    let input_len = 8 * 1024 * 1024 * 1024;
+
+    println!("Input data length: {:.2} GB", input_len as f64 / 1024.0 / 1024.0 / 1024.0);
+
+    let elapse_sha256 = hash::<Sha256>(input_len, "SHA-256  ");
+    let elapse_sha3_256 = hash::<Sha3_256>(input_len, "SHA-3-256");
+    let elapse_blake2 = hash::<Blake2s>(input_len, "Blake2s  ");
+
+    println!("SHA-256: 1.00x, SHA-3-256: {:.2}x, Blake2s: {:.2}x",
+             elapse_sha256 / elapse_sha3_256,
+             elapse_sha256 / elapse_blake2);
+}
+
+fn hash<D: Digest + Default>(input_len: usize, label: &str) -> f64 {
+    let input = generate_input(input_len);
+    let start = Instant::now();
+    let mut hasher = D::default();
+    hasher.input(&input[..]);
+    let digest = hasher.result();
+    let dur = Instant::now() - start;
+    let nano_secs = dur.subsec_nanos() as f64 + dur.as_secs() as f64 * 1e9_f64;
+    println!("{} - {:.2} seconds ({:.0} nano-seconds), digest: {:?}", 
+             label,
+             nano_secs / 1e9_f64, 
+             nano_secs, 
+             HEXLOWER.encode(&digest[..]));
+    nano_secs
+}
+
+fn generate_input(len: usize) -> Vec<u8> {
+    let mut rng = XorShiftRng::from_seed([0, 1, 2, 3]);
+    rng.gen_iter().take(len).collect()
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -30,13 +30,15 @@ fn main() {
     let brick_id = brick::add_brick(brick_name);
 
     let put_op = |brick_id: brick::BrickId, key_str: &str, key: &[u8], value: &[u8]| {
-        brick::put(brick_id, key.to_vec(), value.to_vec())
+        let mut large_value = vec![0; 8 * 1024];
+        large_value[..value.len()].copy_from_slice(value);
+        brick::put(brick_id, key.to_vec(), large_value)
             .expect(&format!("Failed to put a key {}", key_str));
     };
 
     let get_op = |brick_id: brick::BrickId, key_str: &str, key: &[u8], value: &[u8]| {
         let val = brick::get(brick_id, key).expect(&format!("Failed to get a key {}", key_str));
-        assert_eq!(value.to_vec(), val.unwrap());
+        assert_eq!(value, &val.unwrap()[..value.len()]);
     };
 
     do_ops(brick_id, NUM_THREADS, NUM_KEYS_PER_THREAD, "put", put_op);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,9 @@ extern crate lazy_static;
 #[macro_use]
 extern crate serde_derive;
 
+extern crate blake2_rfc;
 extern crate byteorder;
 extern crate data_encoding;
-extern crate generic_array;
-extern crate md_5 as md5;
 extern crate promising_future;
 extern crate rmp_serde as rmps;
 extern crate rocksdb;
@@ -38,7 +37,6 @@ use serde::{Deserialize, Serialize};
 
 use std::io;
 
-//
 // cargo rustc --lib -- -Z unstable-options --unpretty=''hir,typed'' (zsh)
 // cargo rustc --lib -- -Z unstable-options --unpretty=hir,typed     (bash)
 // cargo rustc --lib -- -Z unstable-options --unpretty=mir
@@ -51,13 +49,9 @@ pub mod hlog {
 pub use hlog::wal::BrickId;
 use hlog::wal::{PutBlobResult, WalPosition, WalWriter};
 
-// Type Defs
-
 pub type Etag = String;
 // pub type Metadata
 // pub type TTL
-
-// Consts / Statics
 
 // TODO: Configurable
 const MAIN_DB_PATH: &'static str = "/tmp/hibari-brick-test-data-rocksdb";
@@ -70,10 +64,6 @@ lazy_static! {
         DB::open(&opts, MAIN_DB_PATH).unwrap()
     };
 }
-
-// Structs
-
-// Public API
 
 pub fn add_brick(brick_name: &str) -> BrickId {
     WalWriter::add_brick(brick_name)


### PR DESCRIPTION
- Replace MD5 with Blake2b with 32 bytes (256 bits) digest output.
- To be more scalable on multi-core processor, move checksum calculation from the single WAL thread to client threads.
- Update examples/simple to store larger values (8KB).
- Add a simple benchmark of secure hashes: SHA-2, SHA-3, Blake2b and Blake2s

Fixes #9