### PR TITLE
Update RocksDB (5.11.3) and other crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ build = "build.rs"
 [build-dependencies]
 
 [dependencies]
-blake2-rfc = "0.2.17"
-byteorder = "1.0.0"
-data-encoding = "2.0.0-rc.1"
-lazy_static = "0.2.2"
+blake2-rfc = "0.2.18"
+byteorder = "1.2.2"
+data-encoding = "2.1.1"
+lazy_static = "1.0.0"
 promising-future = "0.2.4"
-rmp-serde = "0.13.1"
-rocksdb = "0.6.0"
-serde = "1.0.7"
-serde_derive = "1.0.7"
+rmp-serde = "0.13.7"
+rocksdb = "0.10.0"
+serde = "1.0.37"
+serde_derive = "1.0.37"
 
 clippy = { version = "*", optional = true }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Dropbox and Mozilla (Firefox):
   * More info about rustup.rs:
     [Taking Rust everywhere with rustup](https://blog.rust-lang.org/2016/05/13/rustup.html)
 - Tools and libraries to build RocksDB
-  * On Linux (Ubuntu), `sudo apt install gcc make libgflags-dev`
+  * On Linux (Ubuntu), `sudo apt install clang-5.0 libclang-5.0-dev libgflags-dev llvm-5.0-dev gcc make`
   * On FreeBSD, **TODO**
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
   post:
     - sudo apt update
     - sudo apt install curl file gcc git make openssh-client
-    - sudo apt install libgflags-dev llvm-5.0-dev libclang-5.0-dev clang-5.0
+    - sudo apt install libgflags-dev llvm-3.9-dev libclang-3.9-dev clang-3.9
     # Delete .gitconfig to prevent "cargo install" and "cargo build" from
     # failing when pulling the registry info (crates.io-index).
     # See https://github.com/rust-lang-ja/rust-by-example-ja/issues/38#issuecomment-238214915

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
   post:
     - sudo apt update
     - sudo apt install curl file gcc git make openssh-client
-    - sudo apt install libgflags-dev
+    - sudo apt install libgflags-dev llvm-5.0-dev libclang-5.0-dev clang-5.0
     # Delete .gitconfig to prevent "cargo install" and "cargo build" from
     # failing when pulling the registry info (crates.io-index).
     # See https://github.com/rust-lang-ja/rust-by-example-ja/issues/38#issuecomment-238214915


### PR DESCRIPTION
- Update rust-rocksdb 0.6.0 -> 0.10.0
- Update other crates to the latest versions

Fixes: #16